### PR TITLE
[Feat] ダッシュボード用のstart workoutボタン追加

### DIFF
--- a/src/components/common/Button.stories.ts
+++ b/src/components/common/Button.stories.ts
@@ -26,8 +26,17 @@ export const Signin = {
     entry: "signin",
   },
 };
+
 export const Signup = {
   args: {
     entry: "signup",
   },
 };
+
+export const StartWorkout = {
+  args: {
+    entry: "startworkout",
+  },
+};
+
+

--- a/src/components/common/Button.stories.ts
+++ b/src/components/common/Button.stories.ts
@@ -8,7 +8,7 @@ const meta: Meta<typeof Button> = {
   parameters: {
     docs: {
       description: {
-        component: "ログイン/サインアップフォーム用ボタン",
+        component: "ログイン/サインアップフォーム、スタートワークアウト用ボタン",
       },
     },
   },

--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -11,6 +11,9 @@ const Button = ({ entry }: ButtonType) => {
     case "signup":
       buttonTxt = "Sign up";
       break;
+    case "startworkout":
+      buttonTxt = "Start Workout";
+      break;
   }
 
   return (

--- a/src/components/common/types.d.ts
+++ b/src/components/common/types.d.ts
@@ -1,4 +1,3 @@
 export type ButtonType = {
-  entry: "signin" | "signup";
+  entry: "signin" | "signup" | "startworkout";
 };
-


### PR DESCRIPTION
## 📝 概要
- ダッシュボード用のstart workoutボタン追加

## 🧐 なぜこの変更をするのか
- ダッシュボードにstart workoutボタンを表示させたいから

### 影響のある Issue
#18 
Closes #

### 参照する Issue や PR
#15
#17 

## 💪 やったこと

- Buttonコンポーネントにstart workoutを追加

### スクリーンショット/動画/gif など

### テスト

- [ ] あり
- [x] なし(必要なし)
- [ ] なし(ヘルプが必要)

## 💬 課題

### 悩んでいること

### とくにレビューしてほしいところ

## その他
