### PR TITLE
[Feat] Exercises API 追加

### DIFF
--- a/src/app/api/exercises/route.test.ts
+++ b/src/app/api/exercises/route.test.ts
@@ -89,8 +89,6 @@ describe("API: exercises", () => {
       });
       const response = await DELETE(req);
 
-      console.log("response ", response);
-
       expect(response.status).toBe(204);
     });
     test("削除トレーニング種目が存在しない", async () => {

--- a/src/app/api/exercises/route.test.ts
+++ b/src/app/api/exercises/route.test.ts
@@ -1,11 +1,37 @@
-import { GET } from "./route";
+import { createMocks } from "node-mocks-http";
+import { GET, POST } from "./route";
+import { type NextApiRequest } from "next";
 
 describe("API: exercises", () => {
-  test("トレーニング種目を全て取得", async () => {
-    const response = await GET();
-    const body = await response.json();
+  describe("GET", () => {
+    test("トレーニング種目を全て取得", async () => {
+      const response = await GET();
+      const body = await response.json();
 
-    expect(response.status).toBe(200);
-    expect(body.length).toBeGreaterThan(0);
+      expect(response.status).toBe(200);
+      expect(body.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("POST", () => {
+    const newExercise = {
+      name: "Overhead Press",
+    };
+    const { req }: { req: NextApiRequest } = createMocks({
+      method: "POST",
+      body: newExercise,
+      headers: { "Content-Type": "application/json" },
+    });
+
+    test("トレーニング種目を追加", async () => {
+      const response = await POST(req);
+
+      expect(response.status).toBe(201);
+    });
+    test("追加トレーニング種目が既に存在する", async () => {
+      const response = await POST(req);
+
+      expect(response.status).toBe(409);
+    });
   });
 });

--- a/src/app/api/exercises/route.test.ts
+++ b/src/app/api/exercises/route.test.ts
@@ -1,0 +1,10 @@
+import { GET } from "./route";
+
+describe("API: exercises", () => {
+  test("トレーニング種目を全て取得", async () => {
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual(["Bench Press", "Squat", "Deadlift"]);
+  });
+});

--- a/src/app/api/exercises/route.test.ts
+++ b/src/app/api/exercises/route.test.ts
@@ -3,8 +3,9 @@ import { GET } from "./route";
 describe("API: exercises", () => {
   test("トレーニング種目を全て取得", async () => {
     const response = await GET();
+    const body = await response.json();
 
     expect(response.status).toBe(200);
-    expect(response.body).toEqual(["Bench Press", "Squat", "Deadlift"]);
+    expect(body.length).toBeGreaterThan(0);
   });
 });

--- a/src/app/api/exercises/route.test.ts
+++ b/src/app/api/exercises/route.test.ts
@@ -1,5 +1,5 @@
 import { createMocks } from "node-mocks-http";
-import { GET, POST, PATCH } from "./route";
+import { GET, POST, PATCH, DELETE } from "./route";
 import { type NextApiRequest } from "next";
 
 describe("API: exercises", () => {
@@ -75,6 +75,31 @@ describe("API: exercises", () => {
         headers: { "Content-Type": "application/json" },
       });
       const response = await PATCH(req);
+
+      expect(response.status).toBe(404);
+    });
+  });
+
+  describe("DELETE", () => {
+    test("トレーニング種目を削除", async () => {
+      const { req }: { req: NextApiRequest } = createMocks({
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: { id: "48" },
+      });
+      const response = await DELETE(req);
+
+      console.log("response ", response);
+
+      expect(response.status).toBe(204);
+    });
+    test("削除トレーニング種目が存在しない", async () => {
+      const { req }: { req: NextApiRequest } = createMocks({
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: { id: "1000" },
+      });
+      const response = await DELETE(req);
 
       expect(response.status).toBe(404);
     });

--- a/src/app/api/exercises/route.test.ts
+++ b/src/app/api/exercises/route.test.ts
@@ -1,5 +1,5 @@
 import { createMocks } from "node-mocks-http";
-import { GET, POST } from "./route";
+import { GET, POST, PATCH } from "./route";
 import { type NextApiRequest } from "next";
 
 describe("API: exercises", () => {
@@ -32,6 +32,51 @@ describe("API: exercises", () => {
       const response = await POST(req);
 
       expect(response.status).toBe(409);
+    });
+  });
+
+  describe("PATCH", () => {
+    test("トレーニング種目を更新", async () => {
+      const updatedExercise = {
+        id: 1,
+        name: "Bench Press (updated)",
+      };
+      const { req }: { req: NextApiRequest } = createMocks({
+        method: "PATCH",
+        body: updatedExercise,
+        headers: { "Content-Type": "application/json" },
+      });
+      const response = await PATCH(req);
+
+      expect(response.status).toBe(200);
+    });
+    test("更新トレーニング種目が既に存在する", async () => {
+      const existentExercise = {
+        id: 1,
+        name: "Squat",
+      };
+      const { req }: { req: NextApiRequest } = createMocks({
+        method: "PATCH",
+        body: existentExercise,
+        headers: { "Content-Type": "application/json" },
+      });
+      const response = await PATCH(req);
+
+      expect(response.status).toBe(409);
+    });
+    test("更新トレーニング種目が存在しない", async () => {
+      const nonExistentExercise = {
+        id: 1000,
+        name: "Bench Press",
+      };
+      const { req }: { req: NextApiRequest } = createMocks({
+        method: "PATCH",
+        body: nonExistentExercise,
+        headers: { "Content-Type": "application/json" },
+      });
+      const response = await PATCH(req);
+
+      expect(response.status).toBe(404);
     });
   });
 });

--- a/src/app/api/exercises/route.ts
+++ b/src/app/api/exercises/route.ts
@@ -1,0 +1,1 @@
+export async function GET() {}

--- a/src/app/api/exercises/route.ts
+++ b/src/app/api/exercises/route.ts
@@ -1,1 +1,19 @@
-export async function GET() {}
+import { createClient } from "@supabase/supabase-js";
+
+export async function GET() {
+  try {
+    const client = createClient(
+      process.env.SUPABASE_URL as string,
+      process.env.SUPABASE_ANON_KEY as string
+    );
+    const { data, error } = await client.from("exercises").select("name");
+
+    if (error) {
+      throw error;
+    }
+    return new Response(JSON.stringify(data));
+  } catch (err) {
+    console.log(err);
+    return new Response("サーバーエラーが発生しました", { status: 500 });
+  }
+}

--- a/src/app/api/exercises/route.ts
+++ b/src/app/api/exercises/route.ts
@@ -1,4 +1,5 @@
 import { createClient } from "@supabase/supabase-js";
+import { type NextApiRequest } from "next";
 
 export async function GET() {
   try {
@@ -8,12 +9,34 @@ export async function GET() {
     );
     const { data, error } = await client.from("exercises").select("name");
 
-    if (error) {
-      throw error;
-    }
+    if (error) throw error;
+
     return new Response(JSON.stringify(data));
   } catch (err) {
     console.log(err);
+    return new Response("サーバーエラーが発生しました", { status: 500 });
+  }
+}
+export async function POST(req: NextApiRequest) {
+  const newExercise = req.body;
+
+  try {
+    const client = createClient(
+      process.env.SUPABASE_URL as string,
+      process.env.SUPABASE_ANON_KEY as string
+    );
+    const { error } = await client.from("exercises").insert(newExercise);
+
+    if (error) {
+      if (error.code === "23505")
+        return new Response("既に存在するトレーニング種目です", {
+          status: 409,
+        });
+      return new Response("サーバーエラーが発生しました", { status: 500 });
+    }
+
+    return new Response("トレーニング種目が追加されました", { status: 201 });
+  } catch (err) {
     return new Response("サーバーエラーが発生しました", { status: 500 });
   }
 }

--- a/src/app/api/exercises/route.ts
+++ b/src/app/api/exercises/route.ts
@@ -40,3 +40,32 @@ export async function POST(req: NextApiRequest) {
     return new Response("サーバーエラーが発生しました", { status: 500 });
   }
 }
+
+export async function PATCH(req: NextApiRequest) {
+  try {
+    const client = createClient(
+      process.env.SUPABASE_URL as string,
+      process.env.SUPABASE_ANON_KEY as string
+    );
+    const { data, error } = await client
+      .from("exercises")
+      .update({ name: req.body.name })
+      .eq("id", req.body.id)
+      .select();
+
+    if (error?.code === "23505")
+      return new Response("既に存在するトレーニング種目です", {
+        status: 409,
+      });
+    if (data?.length === 0) {
+      return new Response("存在しないトレーニング種目です", { status: 404 });
+    }
+    if (error) {
+      return new Response("サーバーエラーが発生しました", { status: 500 });
+    }
+
+    return new Response("トレーニング種目が更新されました", { status: 200 });
+  } catch (err) {
+    return new Response("サーバーエラーが発生しました", { status: 500 });
+  }
+}

--- a/src/app/api/exercises/route.ts
+++ b/src/app/api/exercises/route.ts
@@ -69,3 +69,25 @@ export async function PATCH(req: NextApiRequest) {
     return new Response("サーバーエラーが発生しました", { status: 500 });
   }
 }
+
+export async function DELETE(req: NextApiRequest) {
+  try {
+    const id = req.body.id;
+    const client = createClient(
+      process.env.SUPABASE_URL as string,
+      process.env.SUPABASE_ANON_KEY as string
+    );
+    const { data, error } = await client
+      .from("exercises")
+      .delete()
+      .eq("id", id)
+      .select();
+
+    if (data?.length === 0) {
+      return new Response("存在しないトレーニング種目です", { status: 404 });
+    }
+    return new Response("トレーニング種目が削除されました", { status: 204 });
+  } catch (err) {
+    return new Response("サーバーエラーが発生しました", { status: 500 });
+  }
+}


### PR DESCRIPTION
## 📝 概要
トレーニング種目用のAPI構築

## 🧐 なぜこの変更をするのか
- トレーニング追加の際の種目一覧表示
- トレーニング種目のCRUD操作機能

### 影響のある Issue

Closes #65 

### 参照する Issue や PR

## 💪 やったこと

-`/exercises`ルート作成
- CRUD操作のための各HTTP methods追加 `GET` `POST` `PATCH` `DELETE`

### スクリーンショット/動画/gif など

### テスト

- [x] あり
- [ ] なし(必要なし)
- [ ] なし(ヘルプが必要)

## 💬 課題

### 悩んでいること

### とくにレビューしてほしいところ

## その他
