### PR TITLE
[Feat] ログイン/サインアップページからダッシュボードページへの遷移

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,0 +1,7 @@
+import { NextPage } from "next";
+
+const Page: NextPage = () => {
+  return <></>;
+};
+
+export default Page;

--- a/src/app/signin/page.tsx
+++ b/src/app/signin/page.tsx
@@ -1,10 +1,16 @@
+"use client";
+
 import type { NextPage } from "next";
+import { useRouter } from "next/navigation";
 import { Form } from "@/components";
 
 const Page: NextPage = () => {
+  const router = useRouter();
+  const onClick = () => router.push("/dashboard");
+
   return (
     <>
-      <Form entry="signin" />
+      <Form entry="signin" onClick={onClick} />
     </>
   );
 };

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -1,10 +1,16 @@
+"use client";
+
 import type { NextPage } from "next";
+import { useRouter } from "next/navigation";
 import { Form } from "@/components";
 
 const Page: NextPage = () => {
+  const router = useRouter();
+  const onClick = () => router.push("/dashboard");
+
   return (
     <>
-      <Form entry="signup" />
+      <Form entry="signup" onClick={onClick} />
     </>
   );
 };

--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -8,8 +8,16 @@ const Button = ({ entry, onClick }: ButtonProps) => {
     <div>
       <div className="max-w-md w-full">
         <div className="!mt-8">
-          {entry === "signin" && <button className={className}>SIGN IN</button>}
-          {entry === "signup" && <button className={className}>SIGN UP</button>}
+          {entry === "signin" && (
+            <button className={className} onClick={onClick}>
+              SIGN IN
+            </button>
+          )}
+          {entry === "signup" && (
+            <button className={className} onClick={onClick}>
+              SIGN UP
+            </button>
+          )}
           {entry === "startworkout" && (
             <button className={className}>START WORKOUT</button>
           )}

--- a/src/components/common/Form.tsx
+++ b/src/components/common/Form.tsx
@@ -2,12 +2,12 @@ import React from "react";
 import { Input, Button } from "@/components";
 import { ButtonProps } from "./types";
 
-const Form = ({ entry }: ButtonProps) => {
+const Form = ({ entry, onClick }: ButtonProps) => {
   return (
     <div>
       <Input variant="Email" />
       <Input variant="Password" />
-      <Button entry={entry} />
+      <Button entry={entry} onClick={onClick} />
     </div>
   );
 };


### PR DESCRIPTION
## 📝 概要
ログイン/サインアップページからダッシュボードページへの遷移

## 🧐 なぜこの変更をするのか
ユーザ認証後にダッシュボードページへの遷移処理があるため

### 影響のある Issue

Closes #75 

### 参照する Issue や PR

## 💪 やったこと

- `/dashboard`ルートの作成
- `<Form />`, `<Button />`のonClick用props受け取り追加
- ログイン/サインアップページからフォームへのリダイレクト関数(ログイン→ダッシュボード)受け渡し

### スクリーンショット/動画/gif など
#### Signup
![localhost_3000_signup](https://github.com/user-attachments/assets/0abde7e1-6726-4b1d-a744-292acc6bfae9)
#### Signin
![localhost_3000_signin](https://github.com/user-attachments/assets/3d0a1a18-ea81-4e51-ab8e-913a73b3bc77)

### テスト

- [ ] あり
- [x] なし(必要なし)
- [ ] なし(ヘルプが必要)

## 💬 課題

### 悩んでいること

### とくにレビューしてほしいところ

## その他
