### PR TITLE
[Util] Signup/Login用のutil関数作成

### DIFF
--- a/src/app/api/login/route.ts
+++ b/src/app/api/login/route.ts
@@ -1,8 +1,8 @@
 import { createClient } from "@supabase/supabase-js";
-import { NextApiRequest } from "next";
+import { NextRequest } from "next/server";
 
-export async function POST(req: NextApiRequest) {
-  const { email, password } = req.body;
+export async function POST(req: NextRequest) {
+  const { email, password } = await req.json();
 
   try {
     const supabase = createClient(

--- a/src/app/api/signup/route.ts
+++ b/src/app/api/signup/route.ts
@@ -1,8 +1,8 @@
 import { createClient } from "@supabase/supabase-js";
-import { NextApiRequest } from "next";
+import { NextRequest } from "next/server";
 
-export async function POST(req: NextApiRequest) {
-  const { email, password } = req.body;
+export async function POST(req: NextRequest) {
+  const { email, password } = await req.json();
 
   try {
     const supabase = createClient(

--- a/src/utils/validateLoginUser.test.ts
+++ b/src/utils/validateLoginUser.test.ts
@@ -1,0 +1,18 @@
+import { validateLoginUser } from "./validateLoginUser";
+
+describe("Login APIコール用のUtil関数", () => {
+  describe("ログイン成功", () => {
+    // test("＿", async () => {
+    //   const res = await validateLoginUser("newuser@xyz.com", "newuser");
+    //   expect(res?.isValidLoginUser).toBeTruthy();
+    // });
+  });
+
+  describe("ログイン失敗", () => {
+    test("Emailが存在しない", async () => {
+      //   const res = await validateLoginUser("test@xyz.com", "test");
+      //   expect(res?.isValidLoginUser).toBeFalsy();
+      //   expect(res?.msg).toEqual("Emailが既に使われています");
+    });
+  });
+});

--- a/src/utils/validateLoginUser.test.ts
+++ b/src/utils/validateLoginUser.test.ts
@@ -2,17 +2,28 @@ import { validateLoginUser } from "./validateLoginUser";
 
 describe("Login APIコール用のUtil関数", () => {
   describe("ログイン成功", () => {
-    // test("＿", async () => {
-    //   const res = await validateLoginUser("newuser@xyz.com", "newuser");
-    //   expect(res?.isValidLoginUser).toBeTruthy();
-    // });
+    test("＿", async () => {
+      const res = await validateLoginUser("newuser@xyz.com", "newuser");
+
+      expect(res?.isValidLoginUser).toBeTruthy();
+    });
   });
 
   describe("ログイン失敗", () => {
-    test("Emailが存在しない", async () => {
-      //   const res = await validateLoginUser("test@xyz.com", "test");
-      //   expect(res?.isValidLoginUser).toBeFalsy();
-      //   expect(res?.msg).toEqual("Emailが既に使われています");
+    test("登録なし", async () => {
+      const res = await validateLoginUser(
+        "nonexistentuser@xyz.com",
+        "noexistentuser"
+      );
+
+      expect(res?.isValidLoginUser).toBeFalsy();
+      expect(res?.msg).toEqual("存在しないユーザーです");
+    });
+    test("パスワード間違い", async () => {
+      const res = await validateLoginUser("test@xyz.com", "wrongpassword");
+
+      expect(res?.isValidLoginUser).toBeFalsy();
+      expect(res?.msg).toEqual("パスワードが間違っています");
     });
   });
 });

--- a/src/utils/validateLoginUser.ts
+++ b/src/utils/validateLoginUser.ts
@@ -1,0 +1,14 @@
+export const validateLoginUser = async (email: string, password: string) => {
+  try {
+    const response = await fetch("http://localhost:3000/api/login", {
+      method: "POST",
+      body: JSON.stringify({ email: email, password: password }),
+    });
+    const isValidLoginUser = response.status === 200;
+    const msg = await response.text();
+
+    return { isValidLoginUser: isValidLoginUser, msg: msg };
+  } catch (err) {
+    console.log(err);
+  }
+};

--- a/src/utils/validateLoginUser.ts
+++ b/src/utils/validateLoginUser.ts
@@ -4,6 +4,7 @@ export const validateLoginUser = async (email: string, password: string) => {
       method: "POST",
       body: JSON.stringify({ email: email, password: password }),
     });
+
     const isValidLoginUser = response.status === 200;
     const msg = await response.text();
 

--- a/src/utils/validateSignupUser.test.ts
+++ b/src/utils/validateSignupUser.test.ts
@@ -1,0 +1,20 @@
+import { validateSignupUser } from "./validateSignupUser";
+
+describe("Signup APIコール用のUtil関数", () => {
+  describe("サインアップ成功", () => {
+    test("＿", async () => {
+      const res = await validateSignupUser("newuser@xyz.com", "newuser");
+
+      expect(res?.isSignedUp).toBeTruthy();
+    });
+  });
+
+  describe("サインアップ失敗", () => {
+    test("Emailが既に登録済み", async () => {
+      const res = await validateSignupUser("test@xyz.com", "test");
+
+      expect(res?.isSignedUp).toBeFalsy();
+      expect(res?.msg).toEqual("Emailが既に使われています");
+    });
+  });
+});

--- a/src/utils/validateSignupUser.ts
+++ b/src/utils/validateSignupUser.ts
@@ -1,0 +1,14 @@
+export const validateSignupUser = async (email: string, password: string) => {
+  try {
+    const response = await fetch("http://localhost:3000/api/signup", {
+      method: "POST",
+      body: JSON.stringify({ email: email, password: password }),
+    });
+    const isSignedUp = response.status === 200;
+    const msg = await response.text();
+
+    return { isSignedUp: isSignedUp, msg: msg };
+  } catch (err) {
+    console.log(err);
+  }
+};


### PR DESCRIPTION
## 📝 概要
Signup/Login APIへのauth処理用のutil関数

## 🧐 なぜこの変更をするのか
FE側のauth処理のコードを読みやすく

### 影響のある Issue

Closes #87 

### 参照する Issue や PR

## 💪 やったこと

- `/api/signup`のリクエストボディの値取得修正
- `/api/signup`用のutil関数`validateSignupUser`を作成
- `/api/login`のリクエストボディの値取得修正
- `/api/login`用のutil関数`validateLoginUser`を作成

### スクリーンショット/動画/gif など

### テスト

- [x] あり
- [ ] なし(必要なし)
- [ ] なし(ヘルプが必要)

## 💬 課題

### 悩んでいること

### とくにレビューしてほしいところ

## その他
