### PR TITLE
[Feat] ログイン認証後のアプリ全体でのユーザ情報共有

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,19 +1,25 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import type { NextPage } from "next";
 import { Button, Navbar } from "@/components";
 import { useRouter } from "next/navigation";
-import { useLoginUser } from "@/hooks/useLoginUser";
 
 const Page: NextPage = () => {
-  const { loginUser } = useLoginUser();
+  const [email, setEmail] = useState("");
   const router = useRouter();
   const onClick = () => router.push("/workout");
+
+  useEffect(() => {
+    const storedEmail = localStorage.getItem("email");
+
+    setEmail(storedEmail ?? "Guest");
+  }, []);
 
   return (
     <div className="relative">
       <div className="fixed top-0 left-0 w-full">
-        <Navbar userEmail={loginUser?.email ?? "Guest"} />
+        <Navbar userEmail={email} />
       </div>
       <div className="flex flex-col items-center justify-center pt-16">
         <Button entry="startworkout" onClick={onClick} />

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -3,15 +3,17 @@
 import type { NextPage } from "next";
 import { Button, Navbar } from "@/components";
 import { useRouter } from "next/navigation";
+import { useLoginUser } from "@/hooks/useLoginUser";
 
 const Page: NextPage = () => {
+  const { loginUser } = useLoginUser();
   const router = useRouter();
   const onClick = () => router.push("/workout");
 
   return (
     <div className="relative">
       <div className="fixed top-0 left-0 w-full">
-        <Navbar userEmail="test@xyz.com" />
+        <Navbar userEmail={loginUser?.email ?? "Guest"} />
       </div>
       <div className="flex flex-col items-center justify-center pt-16">
         <Button entry="startworkout" onClick={onClick} />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,3 @@
-import { LoginUserProvider } from "@/contexts/LoginUserContext";
 import "./globals.css";
 
 export default function RootLayout({
@@ -8,9 +7,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body>
-        <LoginUserProvider>{children}</LoginUserProvider>
-      </body>
+      <body>{children}</body>
     </html>
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,4 @@
-import { Navbar } from "@/components";
+import { LoginUserProvider } from "@/contexts/LoginUserContext";
 import "./globals.css";
 
 export default function RootLayout({
@@ -9,10 +9,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body>
-        <div className="fixed top-0 left-0 w-full">
-          <Navbar userEmail={"test@xyz.com"} />
-        </div>
-        {children}
+        <LoginUserProvider>{children}</LoginUserProvider>
       </body>
     </html>
   );

--- a/src/app/signin/page.tsx
+++ b/src/app/signin/page.tsx
@@ -1,16 +1,39 @@
 "use client";
 
+import { useState } from "react";
 import type { NextPage } from "next";
 import { useRouter } from "next/navigation";
 import { Form } from "@/components";
+import { validateLoginUser } from "@/utils/validateLoginUser";
+import { useLoginUser } from "@/hooks/useLoginUser";
 
 const Page: NextPage = () => {
+  const [email, setEmail] = useState("");
+  const [pswd, setPswd] = useState("");
+  const { setLoginUser } = useLoginUser();
   const router = useRouter();
-  const onClick = () => router.push("/dashboard");
+  const onClick = async (e: React.MouseEvent<HTMLInputElement>) => {
+    e.preventDefault();
+
+    const res = await validateLoginUser(email, pswd);
+
+    if (res?.isValidLoginUser) {
+      setLoginUser({ email: email, password: pswd });
+      router.push("/dashboard");
+      return;
+    }
+  };
 
   return (
     <>
-      <Form entry="signin" onClick={onClick} />
+      <Form
+        entry="signin"
+        onClick={onClick}
+        email={email}
+        setEmail={setEmail}
+        pswd={pswd}
+        setPswd={setPswd}
+      />
     </>
   );
 };

--- a/src/app/signin/page.tsx
+++ b/src/app/signin/page.tsx
@@ -5,12 +5,10 @@ import type { NextPage } from "next";
 import { useRouter } from "next/navigation";
 import { Form } from "@/components";
 import { validateLoginUser } from "@/utils/validateLoginUser";
-import { useLoginUser } from "@/hooks/useLoginUser";
 
 const Page: NextPage = () => {
   const [email, setEmail] = useState("");
   const [pswd, setPswd] = useState("");
-  const { setLoginUser } = useLoginUser();
   const router = useRouter();
   const onClick = async (e: React.MouseEvent<HTMLInputElement>) => {
     e.preventDefault();
@@ -18,7 +16,9 @@ const Page: NextPage = () => {
     const res = await validateLoginUser(email, pswd);
 
     if (res?.isValidLoginUser) {
-      setLoginUser({ email: email, password: pswd });
+      localStorage.setItem("email", email);
+      localStorage.setItem("password", pswd);
+
       router.push("/dashboard");
       return;
     }

--- a/src/components/common/Form.tsx
+++ b/src/components/common/Form.tsx
@@ -1,12 +1,35 @@
 import React from "react";
 import { Input, Button } from "@/components";
-import { ButtonProps } from "./types";
 
-const Form = ({ entry, onClick }: ButtonProps) => {
+type FormProps = {
+  entry:
+    | "signin"
+    | "signup"
+    | "startworkout"
+    | "finishworkout"
+    | "addset"
+    | "addexercises"
+    | "cancelworkout"
+    | "closeexerciselist";
+  onClick: (e: React.MouseEvent<HTMLInputElement>) => void;
+  email: string;
+  setEmail: React.Dispatch<React.SetStateAction<string>>;
+  pswd: string;
+  setPswd: React.Dispatch<React.SetStateAction<string>>;
+};
+
+const Form = ({
+  entry,
+  onClick,
+  email,
+  setEmail,
+  pswd,
+  setPswd,
+}: FormProps) => {
   return (
     <div>
-      <Input variant="Email" />
-      <Input variant="Password" />
+      <Input variant="Email" value={email} setValue={setEmail} />
+      <Input variant="Password" value={pswd} setValue={setPswd} />
       <Button entry={entry} onClick={onClick} />
     </div>
   );

--- a/src/components/common/Input.tsx
+++ b/src/components/common/Input.tsx
@@ -2,9 +2,14 @@ import React from "react";
 
 type InputProps = {
   variant: "Email" | "Password";
+  value: string;
+  setValue: React.Dispatch<React.SetStateAction<string>>;
 };
 
-const Input = ({ variant }: InputProps) => {
+const Input = ({ variant, value, setValue }: InputProps) => {
+  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setValue(e.target.value);
+  };
   let inputTxt;
 
   switch (variant) {
@@ -28,6 +33,8 @@ const Input = ({ variant }: InputProps) => {
               required
               className="w-full text-gray-800 text-sm border border-gray-300 px-4 py-3 rounded-md outline-blue-600"
               placeholder={`Enter your ${inputTxt}`}
+              value={value}
+              onChange={onChange}
             />
             {inputTxt === "Email" ? (
               <svg

--- a/src/components/common/types.d.ts
+++ b/src/components/common/types.d.ts
@@ -8,5 +8,5 @@ export type ButtonProps = {
     | "addexercises"
     | "cancelworkout"
     | "closeexerciselist";
-  onClick?: () => void;
+  onClick?: (e: any) => void;
 };


### PR DESCRIPTION
## 📝 概要
ログイン後にアプリ全体でログインユーザ情報を使用できるようにする

## 🧐 なぜこの変更をするのか
ログイン認証後にユーザごとのトレーニング履歴などの個別データを表示する必要がある

### 影響のある Issue

Closes #92

### 参照する Issue や PR

## 💪 やったこと

- ログイン後にアプリ全体で情報共有のためアプリ全体を`LoginUserContext`でラップ
- ログインフォームのインプット値管理のため関連するcomponentの修正
- `/signin`でのログイン認証

### スクリーンショット/動画/gif など

### テスト

- [ ] あり
- [x] なし(必要なし)
- [ ] なし(ヘルプが必要)

## 💬 課題

### 悩んでいること

### とくにレビューしてほしいところ

## その他
