### PR TITLE
[Component] Historyコンポーネント追加

### DIFF
--- a/src/components/dashboard/History.stories.ts
+++ b/src/components/dashboard/History.stories.ts
@@ -1,0 +1,77 @@
+import { Meta } from "@storybook/react";
+import { History } from "@/components";
+
+const meta: Meta<typeof History> = {
+  title: "Dashboard/History",
+  component: History,
+  tags: ["autodocs"],
+  parameters: {
+    docs: {
+      description: {
+        component: "ログインユーザのトレーニング履歴",
+      },
+    },
+  },
+  argTypes: {
+    sessions: {
+      description: "トレーニングセッションのリスト",
+    },
+  },
+};
+
+export default meta;
+
+export const Default = {
+  args: {
+    sessions: [
+      {
+        date: "2025-02-05",
+        data: [
+          {
+            name: "Bench Press",
+            sets: [
+              { reps: 10, weight: 50 },
+              { reps: 10, weight: 60 },
+              { reps: 10, weight: 70 },
+            ],
+          },
+          {
+            name: "Squat",
+            sets: [
+              { reps: 10, weight: 50 },
+              { reps: 10, weight: 60 },
+              { reps: 10, weight: 70 },
+            ],
+          },
+        ],
+      },
+      {
+        date: "2025-02-06",
+        data: [
+          {
+            name: "Bench Press",
+            sets: [
+              { reps: 10, weight: 50 },
+              { reps: 10, weight: 60 },
+              { reps: 10, weight: 70 },
+            ],
+          },
+          {
+            name: "Squat",
+            sets: [
+              { reps: 10, weight: 50 },
+              { reps: 10, weight: 60 },
+              { reps: 10, weight: 70 },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+};
+
+export const NoData = {
+  args: {
+    sessions: [],
+  },
+};

--- a/src/components/dashboard/History.tsx
+++ b/src/components/dashboard/History.tsx
@@ -1,4 +1,4 @@
-import { type MouseEventHandler, useState } from "react";
+import { useState } from "react";
 import type { Session, Exercise } from "./types";
 
 const History = ({ sessions }: { sessions: Session[] }) => {

--- a/src/components/dashboard/History.tsx
+++ b/src/components/dashboard/History.tsx
@@ -1,0 +1,84 @@
+import { type MouseEventHandler, useState } from "react";
+
+type Set = {
+  reps: number;
+  weight: number;
+};
+
+type Exercise = {
+  name: string;
+  sets: Set[];
+};
+
+type Session = {
+  date: string;
+  data: Exercise[];
+};
+
+const History = ({ sessions }: { sessions: Session[] }) => {
+  return (
+    <div className="flex flex-col items-center gap-4 w-4/5">
+      <h2 className="font-bold text-4xl text-center">History</h2>
+      {sessions.length === 0 ? (
+        <div className=" w-4/5">
+          <p className="text-center">No data</p>
+        </div>
+      ) : (
+        <Sessions sessions={sessions} />
+      )}
+    </div>
+  );
+};
+
+const Sessions = ({ sessions }: { sessions: Session[] }) => {
+  return (
+    <ul className=" w-4/5">
+      {sessions.map((session, idx) => {
+        return <Session date={session.date} data={session.data} key={idx} />;
+      })}
+    </ul>
+  );
+};
+
+const Session = ({ date, data }: Session) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const onClick = () => {
+    setIsOpen((prev) => !prev);
+  };
+
+  return (
+    <li className="cursor-pointer" onClick={onClick}>
+      <p className="font-semibold border">{date}</p>
+      <div className="ml-4">
+        {isOpen &&
+          data.map((exercise, idx) => (
+            <Exercise name={exercise.name} sets={exercise.sets} key={idx} />
+          ))}
+      </div>
+    </li>
+  );
+};
+
+const Exercise = ({ name, sets }: Exercise) => {
+  return (
+    <li>
+      <p className="underline">{name}</p>
+      <ul className="ml-4">
+        {sets.map((set, idx) => {
+          const setCount = idx + 1;
+
+          return (
+            <li className="flex gap-2" key={idx}>
+              <p>{setCount}</p>
+              <p>
+                {set.weight}kg x {set.reps}
+              </p>
+            </li>
+          );
+        })}
+      </ul>
+    </li>
+  );
+};
+
+export default History;

--- a/src/components/dashboard/History.tsx
+++ b/src/components/dashboard/History.tsx
@@ -1,19 +1,5 @@
 import { type MouseEventHandler, useState } from "react";
-
-type Set = {
-  reps: number;
-  weight: number;
-};
-
-type Exercise = {
-  name: string;
-  sets: Set[];
-};
-
-type Session = {
-  date: string;
-  data: Exercise[];
-};
+import type { Session, Exercise } from "./types";
 
 const History = ({ sessions }: { sessions: Session[] }) => {
   return (

--- a/src/components/dashboard/types.d.ts
+++ b/src/components/dashboard/types.d.ts
@@ -1,0 +1,14 @@
+export type Set = {
+  reps: number;
+  weight: number;
+};
+
+export type Exercise = {
+  name: string;
+  sets: Set[];
+};
+
+export type Session = {
+  date: string;
+  data: Exercise[];
+};

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -10,3 +10,6 @@ export { default as ExerciseList } from "./workout/ExerciseList";
 export { default as ExerciseName } from "./workout/ExerciseName";
 export { default as RecordInput } from "./workout/RecordInput";
 export { default as WorkoutRecord } from "./workout/WorkoutRecord";
+
+/*--- dashboard ---*/
+export { default as History } from "./dashboard/History";


### PR DESCRIPTION
## 📝 概要
ログインユーザのトレーニング履歴を表示するUI

## 🧐 なぜこの変更をするのか
ダッシュボードページでログインユーザのトレーニング履歴を表示するため

### 影響のある Issue

Closes #94 

### 参照する Issue や PR

## 💪 やったこと

- `<History />`作成
- `<History />`をコンポーネント用エントリーポイントに追加

### スクリーンショット/動画/gif など

### テスト

- [ ] あり
- [x] なし(必要なし)
- [ ] なし(ヘルプが必要)

## 💬 課題

### 悩んでいること

### とくにレビューしてほしいところ

## その他
