### PR TITLE
[Feat] ダッシュボードページにログインユーザのトレーニング履歴を表示

### DIFF
--- a/src/app/api/histories/route.ts
+++ b/src/app/api/histories/route.ts
@@ -16,7 +16,7 @@ export async function GET(req: NextRequest) {
 
     if (error) throw error;
     if (data?.length === 0) {
-      return new Response("存在しないトレーニング種目です", { status: 404 });
+      return new Response("データが存在しません", { status: 200 });
     }
 
     return new Response(JSON.stringify(data));

--- a/src/app/api/histories/route.ts
+++ b/src/app/api/histories/route.ts
@@ -1,8 +1,8 @@
 import { createClient } from "@supabase/supabase-js";
-import { type NextApiRequest } from "next";
+import { NextRequest } from "next/server";
 
-export async function GET(req: NextApiRequest) {
-  const email = req.query.email;
+export async function GET(req: NextRequest) {
+  const email = req.nextUrl.searchParams.get("email");
 
   try {
     const client = createClient(
@@ -11,7 +11,7 @@ export async function GET(req: NextApiRequest) {
     );
     const { data, error } = await client
       .from("histories")
-      .select("*")
+      .select("data")
       .eq("email", email);
 
     if (error) throw error;

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -7,13 +7,24 @@ import { useRouter } from "next/navigation";
 
 const Page: NextPage = () => {
   const [email, setEmail] = useState("");
+  const [sessions, setSessions] = useState([]);
+
   const router = useRouter();
   const onClick = () => router.push("/workout");
 
   useEffect(() => {
     const storedEmail = localStorage.getItem("email");
+    const updateUserHistory = async () => {
+      const res = await fetch(
+        `http://localhost:3000/api/histories?email=${storedEmail}`
+      );
+      const data = await res.json();
+
+      setSessions(data[0].data);
+    };
 
     setEmail(storedEmail ?? "Guest");
+    updateUserHistory();
   }, []);
 
   return (
@@ -24,7 +35,7 @@ const Page: NextPage = () => {
       <div className="flex flex-col items-center justify-center pt-16">
         <Button entry="startworkout" onClick={onClick} />
         <div className="w-full min-h-64 flex justify-center items-center">
-          <History sessions={[]} />
+          <History sessions={sessions} />
         </div>
       </div>
     </div>

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import type { NextPage } from "next";
-import { Button, Navbar } from "@/components";
+import { Button, Navbar, History } from "@/components";
 import { useRouter } from "next/navigation";
 
 const Page: NextPage = () => {
@@ -23,7 +23,9 @@ const Page: NextPage = () => {
       </div>
       <div className="flex flex-col items-center justify-center pt-16">
         <Button entry="startworkout" onClick={onClick} />
-        <h1 className="mt-4 bg-gray-200 px-20 py-10">HISTORY</h1>
+        <div className="w-full min-h-64 flex justify-center items-center">
+          <History sessions={[]} />
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## 📝 概要
`/dashboard`でのトレーニング履歴表示

## 🧐 なぜこの変更をするのか
ダッシュボードペーいにトレーニング履歴表示機能をを実装する

### 影響のある Issue

Closes #96 

### 参照する Issue や PR

## 💪 やったこと

- `/histories`APIのエラーメッセージ修正
- `/histories`APIのクエリパラメータ取得バグ修正
- `/dashboard`にログインユーザのトレーニング履歴表示

### スクリーンショット/動画/gif など

### テスト

- [ ] あり
- [x] なし(必要なし)
- [ ] なし(ヘルプが必要)

## 💬 課題

### 悩んでいること

### とくにレビューしてほしいところ

## その他
