### PR TITLE
[Feat] 非認証ユーザのユーザページアクセス時のサインインページ強制リダイレクト

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import type { NextPage } from "next";
-import { Button, Navbar, History } from "@/components";
+import { Button, Navbar, History, NoAuthUserRedirection } from "@/components";
 import { useRouter } from "next/navigation";
 
 const Page: NextPage = () => {
@@ -28,17 +28,19 @@ const Page: NextPage = () => {
   }, []);
 
   return (
-    <div className="relative">
-      <div className="fixed top-0 left-0 w-full">
-        <Navbar userEmail={email} />
-      </div>
-      <div className="flex flex-col items-center justify-center pt-16">
-        <Button entry="startworkout" onClick={onClick} />
-        <div className="w-full min-h-64 flex justify-center items-center">
-          <History sessions={sessions} />
+    <NoAuthUserRedirection>
+      <div className="relative">
+        <div className="fixed top-0 left-0 w-full">
+          <Navbar userEmail={email} />
+        </div>
+        <div className="flex flex-col items-center justify-center pt-16">
+          <Button entry="startworkout" onClick={onClick} />
+          <div className="w-full min-h-64 flex justify-center items-center">
+            <History sessions={sessions} />
+          </div>
         </div>
       </div>
-    </div>
+    </NoAuthUserRedirection>
   );
 };
 

--- a/src/app/workout/page.tsx
+++ b/src/app/workout/page.tsx
@@ -2,7 +2,12 @@
 
 import type { NextPage } from "next";
 import React, { useEffect, useState } from "react";
-import { Button, Exercise, ExerciseListPopUp } from "@/components";
+import {
+  Button,
+  Exercise,
+  ExerciseListPopUp,
+  NoAuthUserRedirection,
+} from "@/components";
 import { useRouter } from "next/navigation";
 
 const Page: NextPage = () => {
@@ -17,7 +22,7 @@ const Page: NextPage = () => {
   }, []);
 
   return (
-    <>
+    <NoAuthUserRedirection>
       {isOpen && (
         <ExerciseListPopUp
           onCancel={() => setIsOpen(false)}
@@ -33,7 +38,7 @@ const Page: NextPage = () => {
         <Button entry="addexercises" onClick={() => setIsOpen(true)} />
         <Button entry="cancelworkout" onClick={onClick} />
       </div>
-    </>
+    </NoAuthUserRedirection>
   );
 };
 

--- a/src/components/common/NoAuthUserRedirection.tsx
+++ b/src/components/common/NoAuthUserRedirection.tsx
@@ -1,0 +1,17 @@
+import { ReactNode } from "react";
+import { useRouter } from "next/navigation";
+
+const NoAuthUserRedirection = ({ children }: { children: ReactNode }) => {
+  const router = useRouter();
+  const email = localStorage.getItem("email");
+  const isAuthed = email !== null && email !== "";
+
+  if (isAuthed) {
+    return <>{children}</>;
+  }
+
+  router.push("/signin");
+  return;
+};
+
+export default NoAuthUserRedirection;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -4,6 +4,7 @@ export { default as Form } from "./common/Form";
 export { default as Input } from "./common/Input";
 export { default as Navbar } from "./common/Navbar";
 export { default as SignoutButton } from "./common/SignoutButton";
+export { default as NoAuthUserRedirection } from "./common/NoAuthUserRedirection";
 
 /*--- workout ---*/
 export { default as Exercise } from "./workout/Exercise";


### PR DESCRIPTION
## 📝 概要
非認証ユーザがユーザページ(`/dashboard`, `/workout`)へアクセスした時にサインインページへリダイレクトされる機能追加

## 🧐 なぜこの変更をするのか
登録ユーザのみアプリ機能を利用できる仕様にするため

### 影響のある Issue

Closes #97 

### 参照する Issue や PR

## 💪 やったこと

- リダイレクト用のコンポーネント作成
- `/dashboard`のページコンポーネントをラップ
- `/workout`のページコンポーネントをラップ

### スクリーンショット/動画/gif など

### テスト

- [ ] あり
- [x] なし(必要なし)
- [ ] なし(ヘルプが必要)

## 💬 課題

### 悩んでいること

### とくにレビューしてほしいところ

## その他
@yurihoka 
コンポーネントは`components/common`に作成しましたが、UIではないのでstoriesファイルを作っていないです
