### PR TITLE
[Feat] StartWorkoutボタンをクリックしてWorkoutページに遷移させる

### DIFF
--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -18,7 +18,9 @@ const Button = ({ entry, onClick }: ButtonProps) => {
           </button>
         )}
         {entry === "startworkout" && (
-          <button className={className}>START WORKOUT</button>
+          <button className={className} onClick={onClick}>
+            START WORKOUT
+          </button>
         )}
         {entry === "finishworkout" && (
           <button className={className}>FINISH WORKOUT</button>


### PR DESCRIPTION
## 📝 概要
- StartWorkoutボタンをクリックしてWorkoutページに遷移させる

## 🧐 なぜこの変更をするのか
- StartWorkoutボタンをクリックしたら、Workoutページに遷移する

### 影響のある Issue

Closes #

### 参照する Issue や PR

## 💪 やったこと
- Buttonコンポーネントの`startworkout`にonClick追加

### スクリーンショット/動画/gif など

### テスト

- [ ] あり
- [x] なし(必要なし)
- [ ] なし(ヘルプが必要)

## 💬 課題

### 悩んでいること

### とくにレビューしてほしいところ

## その他
