### PR TITLE
[Feat] Signupページでの新規ユーザ登録処理追加

### DIFF
--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -27,7 +27,7 @@ const Page: NextPage = () => {
   return (
     <div className="flex items-center justify-center h-screen">
       <Form
-        entry="signin"
+        entry="signup"
         onClick={onClick}
         email={email}
         setEmail={setEmail}

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -1,16 +1,39 @@
 "use client";
 
+import { useState } from "react";
 import type { NextPage } from "next";
 import { useRouter } from "next/navigation";
 import { Form } from "@/components";
+import { validateSignupUser } from "@/utils/validateSignupUser";
 
 const Page: NextPage = () => {
+  const [email, setEmail] = useState("");
+  const [pswd, setPswd] = useState("");
   const router = useRouter();
-  const onClick = () => router.push("/dashboard");
+  const onClick = async (e: React.MouseEvent<HTMLInputElement>) => {
+    e.preventDefault();
+
+    const res = await validateSignupUser(email, pswd);
+
+    if (res?.isSignedUp) {
+      localStorage.setItem("email", email);
+      localStorage.setItem("password", pswd);
+
+      router.push("/dashboard");
+      return;
+    }
+  };
 
   return (
     <div className="flex items-center justify-center h-screen">
-      <Form entry="signup" onClick={onClick} />
+      <Form
+        entry="signin"
+        onClick={onClick}
+        email={email}
+        setEmail={setEmail}
+        pswd={pswd}
+        setPswd={setPswd}
+      />
     </div>
   );
 };


### PR DESCRIPTION
## 📝 概要
Signupページでの新規ユーザ登録処理の追加

## 🧐 なぜこの変更をするのか
ユーザ登録機能実装のため

### 影響のある Issue

Closes #112 

### 参照する Issue や PR

## 💪 やったこと

- `/signup`ページにフォーム内容保持のためのstateを作成
- Signupボタン押下時にユーザ情報stateを使ってSignup APIへのAPIコール追加

### スクリーンショット/動画/gif など

### テスト

- [ ] あり
- [x] なし(必要なし)
- [ ] なし(ヘルプが必要)

## 💬 課題

### 悩んでいること

### とくにレビューしてほしいところ

## その他
