### PR TITLE
[Feat] サインインページ内にサインアップページへのリンクを追加

### DIFF
--- a/src/app/(auth)/signin/page.tsx
+++ b/src/app/(auth)/signin/page.tsx
@@ -5,6 +5,7 @@ import type { NextPage } from "next";
 import { useRouter } from "next/navigation";
 import { Form } from "@/components";
 import { validateLoginUser } from "@/utils/validateLoginUser";
+import Link from "next/link";
 
 const Page: NextPage = () => {
   const [email, setEmail] = useState("");
@@ -25,14 +26,19 @@ const Page: NextPage = () => {
   };
 
   return (
-    <Form
-      entry="signin"
-      onClick={onClick}
-      email={email}
-      setEmail={setEmail}
-      pswd={pswd}
-      setPswd={setPswd}
-    />
+    <div className="flex flex-col items-center justify-center h-screen gap-2">
+      <Form
+        entry="signin"
+        onClick={onClick}
+        email={email}
+        setEmail={setEmail}
+        pswd={pswd}
+        setPswd={setPswd}
+      />
+      <Link href="/signup" className="text-lime-400 hover:text-lime-300">
+        Sign Up
+      </Link>
+    </div>
   );
 };
 

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -24,9 +24,6 @@ const Page: NextPage = () => {
     }
   };
 
-<<<<<<< HEAD:src/app/(auth)/signup/page.tsx
-  return <Form entry="signup" onClick={onClick} />;
-=======
   return (
     <div className="flex items-center justify-center h-screen">
       <Form
@@ -39,7 +36,6 @@ const Page: NextPage = () => {
       />
     </div>
   );
->>>>>>> main:src/app/signup/page.tsx
 };
 
 export default Page;


### PR DESCRIPTION
## 📝 概要
サインインページ内にサインアップページへのリンクを追加

## 🧐 なぜこの変更をするのか
ユーザが最初にアクセスするページはログインページだが、そのページから未登録ユーザがサインアップするためにアクセスするサインアップページへの動線が無かった

### 影響のある Issue

Closes #114 

### 参照する Issue や PR

## 💪 やったこと

- サインインページ内にリンクを作成
- サインアップのページコンポーネントにあった不要なマージメッセージを削除

### スクリーンショット/動画/gif など

### テスト

- [ ] あり
- [x] なし(必要なし)
- [ ] なし(ヘルプが必要)

## 💬 課題

### 悩んでいること

### とくにレビューしてほしいところ

## その他
