### PR TITLE
[Feat] `/` → `/signin`への自動リダイレクト設定追加

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,8 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  async redirects() {
+    return [{ source: "/", destination: "/signin", permanent: true }];
+  },
+};
 
 export default nextConfig;


### PR DESCRIPTION
## 📝 概要
`/`へアクセス時に`/signin`へ自動リダイレクトされる設定追加

## 🧐 なぜこの変更をするのか
`/`は現在何もコンテンツがないので、ユーザの利便性的にsigninへアクセスする方が良い

### 影響のある Issue

Closes #118 

### 参照する Issue や PR

## 💪 やったこと

- nextの設定ファイルに自動リダイレクト設定を追記

### スクリーンショット/動画/gif など

### テスト

- [ ] あり
- [x] なし(必要なし)
- [ ] なし(ヘルプが必要)

## 💬 課題

### 悩んでいること

### とくにレビューしてほしいところ

## その他
