### PR TITLE
[Fix] Cancel Workoutボタンの色変更

### DIFF
--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -38,7 +38,7 @@ const Button = ({ entry, onClick }: ButtonProps) => {
         {entry === "cancelworkout" && (
           <button
             type="button"
-            className={`${className} bg-gray-300`}
+            className="w-full py-3 px-4 text-sm tracking-wide rounded-lg text-white bg-gray-400 mt-2 hover:bg-gray-300 focus:outline-none"
             onClick={onClick}
           >
             CANCEL WORKOUT


### PR DESCRIPTION
## 📝 概要
WorkoutページのCancel Workoutボタンの色変更

## 🧐 なぜこの変更をするのか
Workoutページ内のボタンが全て同色で見辛いため

### 影響のある Issue

Closes #120 

### 参照する Issue や PR

## 💪 やったこと

- `<Button />`のCancel ver.のスタイル変更

### スクリーンショット/動画/gif など

### テスト

- [ ] あり
- [x] なし(必要なし)
- [ ] なし(ヘルプが必要)

## 💬 課題

### 悩んでいること

### とくにレビューしてほしいところ

## その他
