### PR TITLE
[Feat] ユーザ認証フォームのインプットバリデーション

### DIFF
--- a/src/app/(auth)/signin/page.tsx
+++ b/src/app/(auth)/signin/page.tsx
@@ -1,40 +1,13 @@
 "use client";
 
-import { useState } from "react";
 import type { NextPage } from "next";
-import { useRouter } from "next/navigation";
 import { Form } from "@/components";
-import { validateLoginUser } from "@/utils/validateLoginUser";
 import Link from "next/link";
 
 const Page: NextPage = () => {
-  const [email, setEmail] = useState("");
-  const [pswd, setPswd] = useState("");
-  const router = useRouter();
-  const onClick = async (e: React.MouseEvent<HTMLInputElement>) => {
-    e.preventDefault();
-
-    const res = await validateLoginUser(email, pswd);
-
-    if (res?.isValidLoginUser) {
-      localStorage.setItem("email", email);
-      localStorage.setItem("password", pswd);
-
-      router.push("/dashboard");
-      return;
-    }
-  };
-
   return (
     <div className="flex flex-col items-center justify-center h-screen gap-2">
-      <Form
-        entry="signin"
-        onClick={onClick}
-        email={email}
-        setEmail={setEmail}
-        pswd={pswd}
-        setPswd={setPswd}
-      />
+      <Form entry="signin" />
       <Link href="/signup" className="text-lime-400 hover:text-lime-300">
         Sign Up
       </Link>

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -1,39 +1,12 @@
 "use client";
 
-import { useState } from "react";
 import type { NextPage } from "next";
-import { useRouter } from "next/navigation";
 import { Form } from "@/components";
-import { validateSignupUser } from "@/utils/validateSignupUser";
 
 const Page: NextPage = () => {
-  const [email, setEmail] = useState("");
-  const [pswd, setPswd] = useState("");
-  const router = useRouter();
-  const onClick = async (e: React.MouseEvent<HTMLInputElement>) => {
-    e.preventDefault();
-
-    const res = await validateSignupUser(email, pswd);
-
-    if (res?.isSignedUp) {
-      localStorage.setItem("email", email);
-      localStorage.setItem("password", pswd);
-
-      router.push("/dashboard");
-      return;
-    }
-  };
-
   return (
     <div className="flex items-center justify-center h-screen">
-      <Form
-        entry="signup"
-        onClick={onClick}
-        email={email}
-        setEmail={setEmail}
-        pswd={pswd}
-        setPswd={setPswd}
-      />
+      <Form entry="signup" />
     </div>
   );
 };

--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -7,16 +7,8 @@ const Button = ({ entry, onClick }: ButtonProps) => {
   return (
     <div>
       <div className="w-full flex justify-center">
-        {entry === "signin" && (
-          <button type="button" className={className} onClick={onClick}>
-            SIGN IN
-          </button>
-        )}
-        {entry === "signup" && (
-          <button type="button" className={className} onClick={onClick}>
-            SIGN UP
-          </button>
-        )}
+        {entry === "signin" && <button className={className}>SIGN IN</button>}
+        {entry === "signup" && <button className={className}>SIGN UP</button>}
         {entry === "startworkout" && (
           <button type="button" className={className} onClick={onClick}>
             START WORKOUT

--- a/src/components/common/Form.tsx
+++ b/src/components/common/Form.tsx
@@ -1,37 +1,48 @@
+"use client";
+
 import React from "react";
+import { useForm } from "react-hook-form";
+import { useRouter } from "next/navigation";
 import { Input, Button } from "@/components";
+import { validateLoginUser } from "@/utils/validateLoginUser";
+import { validateSignupUser } from "@/utils/validateSignupUser";
 
 type FormProps = {
-  entry:
-    | "signin"
-    | "signup"
-    | "startworkout"
-    | "finishworkout"
-    | "addset"
-    | "addexercises"
-    | "cancelworkout"
-    | "closeexerciselist";
-  onClick: (e: React.MouseEvent<HTMLInputElement>) => void;
-  email: string;
-  setEmail: React.Dispatch<React.SetStateAction<string>>;
-  pswd: string;
-  setPswd: React.Dispatch<React.SetStateAction<string>>;
+  entry: "signin" | "signup";
 };
 
-const Form = ({
-  entry,
-  onClick,
-  email,
-  setEmail,
-  pswd,
-  setPswd,
-}: FormProps) => {
+const Form = ({ entry }: FormProps) => {
+  const { register, handleSubmit } = useForm();
+  const router = useRouter();
+  const onSubmit = (data: any) => {
+    const { email, password } = data;
+    const authorizeUser = async () => {
+      const res =
+        entry === "signin"
+          ? await validateLoginUser(email, password)
+          : await validateSignupUser(email, password);
+
+      if (res?.isSucceeded) {
+        localStorage.setItem("email", email);
+        localStorage.setItem("password", password);
+
+        router.push("/dashboard");
+        return;
+      }
+    };
+
+    authorizeUser();
+  };
+
   return (
-    <div className="flex flex-col items-center justify-center">
-      <Input variant="Email" value={email} setValue={setEmail} />
-      <Input variant="Password" value={pswd} setValue={setPswd} />
-      <Button entry={entry} onClick={onClick} />
-    </div>
+    <form
+      className="flex flex-col items-center justify-center"
+      onSubmit={handleSubmit(onSubmit)}
+    >
+      <Input type="email" register={register} />
+      <Input type="password" register={register} />
+      <Button entry={entry} />
+    </form>
   );
 };
 

--- a/src/components/common/Input.tsx
+++ b/src/components/common/Input.tsx
@@ -7,6 +7,24 @@ type InputProps = {
 };
 
 const Input = ({ type, register }: InputProps) => {
+  const rgstr =
+    type === "email"
+      ? register("email", {
+          required: true,
+          pattern: {
+            value: /[A-Za-z0-9\._\-]+@[A-Za-z0-9\._\-]+\.[A-Za-z]+/,
+            message:
+              "英数字または記号(.-_)を含むメールアドレスを入力してください",
+          },
+        })
+      : register("password", {
+          required: true,
+          pattern: {
+            value: /[A-Za-z0-9]+/,
+            message: "英数字を含むパスワードを入力してください",
+          },
+        });
+
   return (
     <div className="max-w-md w-full">
       <div className="mt-8 space-y-4">
@@ -17,7 +35,7 @@ const Input = ({ type, register }: InputProps) => {
               required
               className="w-full text-gray-800 text-sm border border-gray-300 px-4 py-3 rounded-md outline-blue-600"
               placeholder={`Enter your ${type}`}
-              {...register(type)}
+              {...rgstr}
             />
             {type === "email" ? (
               <svg

--- a/src/components/common/Input.tsx
+++ b/src/components/common/Input.tsx
@@ -6,6 +6,36 @@ type InputProps = {
   register: UseFormRegister<FieldValues>;
 };
 
+const EmailIcon = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="#bbb"
+    stroke="#bbb"
+    className="w-4 h-4 absolute right-4"
+    viewBox="0 0 24 24"
+  >
+    <circle cx="10" cy="7" r="6" data-original="#000000"></circle>
+    <path
+      d="M14 15H6a5 5 0 0 0-5 5 3 3 0 0 0 3 3h12a3 3 0 0 0 3-3 5 5 0 0 0-5-5zm8-4h-2.59l.3-.29a1 1 0 0 0-1.42-1.42l-2 2a1 1 0 0 0 0 1.42l2 2a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42l-.3-.29H22a1 1 0 0 0 0-2z"
+      data-original="#000000"
+    ></path>
+  </svg>
+);
+const PasswordIcon = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="#bbb"
+    stroke="#bbb"
+    className="w-4 h-4 absolute right-4 cursor-pointer"
+    viewBox="0 0 128 128"
+  >
+    <path
+      d="M64 104C22.127 104 1.367 67.496.504 65.943a4 4 0 0 1 0-3.887C1.367 60.504 22.127 24 64 24s62.633 36.504 63.496 38.057a4 4 0 0 1 0 3.887C126.633 67.496 105.873 104 64 104zM8.707 63.994C13.465 71.205 32.146 96 64 96c31.955 0 50.553-24.775 55.293-31.994C114.535 56.795 95.854 32 64 32 32.045 32 13.447 56.775 8.707 63.994zM64 88c-13.234 0-24-10.766-24-24s10.766-24 24-24 24 10.766 24 24-10.766 24-24 24zm0-40c-8.822 0-16 7.178-16 16s7.178 16 16 16 16-7.178 16-16-7.178-16-16-16z"
+      data-original="#000000"
+    ></path>
+  </svg>
+);
+
 const Input = ({ type, register }: InputProps) => {
   const rgstr =
     type === "email"
@@ -37,34 +67,8 @@ const Input = ({ type, register }: InputProps) => {
               placeholder={`Enter your ${type}`}
               {...rgstr}
             />
-            {type === "email" ? (
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                fill="#bbb"
-                stroke="#bbb"
-                className="w-4 h-4 absolute right-4"
-                viewBox="0 0 24 24"
-              >
-                <circle cx="10" cy="7" r="6" data-original="#000000"></circle>
-                <path
-                  d="M14 15H6a5 5 0 0 0-5 5 3 3 0 0 0 3 3h12a3 3 0 0 0 3-3 5 5 0 0 0-5-5zm8-4h-2.59l.3-.29a1 1 0 0 0-1.42-1.42l-2 2a1 1 0 0 0 0 1.42l2 2a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42l-.3-.29H22a1 1 0 0 0 0-2z"
-                  data-original="#000000"
-                ></path>
-              </svg>
-            ) : type === "password" ? (
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                fill="#bbb"
-                stroke="#bbb"
-                className="w-4 h-4 absolute right-4 cursor-pointer"
-                viewBox="0 0 128 128"
-              >
-                <path
-                  d="M64 104C22.127 104 1.367 67.496.504 65.943a4 4 0 0 1 0-3.887C1.367 60.504 22.127 24 64 24s62.633 36.504 63.496 38.057a4 4 0 0 1 0 3.887C126.633 67.496 105.873 104 64 104zM8.707 63.994C13.465 71.205 32.146 96 64 96c31.955 0 50.553-24.775 55.293-31.994C114.535 56.795 95.854 32 64 32 32.045 32 13.447 56.775 8.707 63.994zM64 88c-13.234 0-24-10.766-24-24s10.766-24 24-24 24 10.766 24 24-10.766 24-24 24zm0-40c-8.822 0-16 7.178-16 16s7.178 16 16 16 16-7.178 16-16-7.178-16-16-16z"
-                  data-original="#000000"
-                ></path>
-              </svg>
-            ) : null}
+            {type === "email" && <EmailIcon />}
+            {type === "password" && <PasswordIcon />}
           </div>
         </div>
       </div>

--- a/src/components/common/Input.tsx
+++ b/src/components/common/Input.tsx
@@ -1,42 +1,25 @@
 import React from "react";
+import type { FieldValues, UseFormRegister } from "react-hook-form";
 
 type InputProps = {
-  variant: "Email" | "Password";
-  value: string;
-  setValue: React.Dispatch<React.SetStateAction<string>>;
+  type: "email" | "password";
+  register: UseFormRegister<FieldValues>;
 };
 
-const Input = ({ variant, value, setValue }: InputProps) => {
-  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setValue(e.target.value);
-  };
-  let inputTxt;
-
-  switch (variant) {
-    case "Email":
-      inputTxt = "Email";
-      break;
-    case "Password":
-      inputTxt = "Password";
-      break;
-  }
-
+const Input = ({ type, register }: InputProps) => {
   return (
     <div className="max-w-md w-full">
-      <form className="mt-8 space-y-4">
+      <div className="mt-8 space-y-4">
         <div>
-          <label className="text-gray-800 text-sm mb-2 block">{inputTxt}</label>
+          <label className="text-gray-800 text-sm mb-2 block">{type}</label>
           <div className="relative flex items-center">
             <input
-              name={inputTxt}
-              type={inputTxt}
               required
               className="w-full text-gray-800 text-sm border border-gray-300 px-4 py-3 rounded-md outline-blue-600"
-              placeholder={`Enter your ${inputTxt}`}
-              value={value}
-              onChange={onChange}
+              placeholder={`Enter your ${type}`}
+              {...register(type)}
             />
-            {inputTxt === "Email" ? (
+            {type === "email" ? (
               <svg
                 xmlns="http://www.w3.org/2000/svg"
                 fill="#bbb"
@@ -50,7 +33,7 @@ const Input = ({ variant, value, setValue }: InputProps) => {
                   data-original="#000000"
                 ></path>
               </svg>
-            ) : inputTxt === "Password" ? (
+            ) : type === "password" ? (
               <svg
                 xmlns="http://www.w3.org/2000/svg"
                 fill="#bbb"
@@ -66,7 +49,7 @@ const Input = ({ variant, value, setValue }: InputProps) => {
             ) : null}
           </div>
         </div>
-      </form>
+      </div>
     </div>
   );
 };

--- a/src/utils/validateLoginUser.test.ts
+++ b/src/utils/validateLoginUser.test.ts
@@ -5,7 +5,7 @@ describe("Login APIコール用のUtil関数", () => {
     test("＿", async () => {
       const res = await validateLoginUser("newuser@xyz.com", "newuser");
 
-      expect(res?.isValidLoginUser).toBeTruthy();
+      expect(res?.isSucceeded).toBeTruthy();
     });
   });
 
@@ -16,13 +16,13 @@ describe("Login APIコール用のUtil関数", () => {
         "noexistentuser"
       );
 
-      expect(res?.isValidLoginUser).toBeFalsy();
+      expect(res?.isSucceeded).toBeFalsy();
       expect(res?.msg).toEqual("存在しないユーザーです");
     });
     test("パスワード間違い", async () => {
       const res = await validateLoginUser("test@xyz.com", "wrongpassword");
 
-      expect(res?.isValidLoginUser).toBeFalsy();
+      expect(res?.isSucceeded).toBeFalsy();
       expect(res?.msg).toEqual("パスワードが間違っています");
     });
   });

--- a/src/utils/validateLoginUser.ts
+++ b/src/utils/validateLoginUser.ts
@@ -5,10 +5,10 @@ export const validateLoginUser = async (email: string, password: string) => {
       body: JSON.stringify({ email: email, password: password }),
     });
 
-    const isValidLoginUser = response.status === 200;
+    const isSucceeded = response.status === 200;
     const msg = await response.text();
 
-    return { isValidLoginUser: isValidLoginUser, msg: msg };
+    return { isSucceeded: isSucceeded, msg: msg };
   } catch (err) {
     console.log(err);
   }

--- a/src/utils/validateSignupUser.test.ts
+++ b/src/utils/validateSignupUser.test.ts
@@ -5,7 +5,7 @@ describe("Signup APIコール用のUtil関数", () => {
     test("＿", async () => {
       const res = await validateSignupUser("newuser@xyz.com", "newuser");
 
-      expect(res?.isSignedUp).toBeTruthy();
+      expect(res?.isSucceeded).toBeTruthy();
     });
   });
 
@@ -13,7 +13,7 @@ describe("Signup APIコール用のUtil関数", () => {
     test("Emailが既に登録済み", async () => {
       const res = await validateSignupUser("test@xyz.com", "test");
 
-      expect(res?.isSignedUp).toBeFalsy();
+      expect(res?.isSucceeded).toBeFalsy();
       expect(res?.msg).toEqual("Emailが既に使われています");
     });
   });

--- a/src/utils/validateSignupUser.ts
+++ b/src/utils/validateSignupUser.ts
@@ -4,10 +4,10 @@ export const validateSignupUser = async (email: string, password: string) => {
       method: "POST",
       body: JSON.stringify({ email: email, password: password }),
     });
-    const isSignedUp = response.status === 200;
+    const isSucceeded = response.status === 200;
     const msg = await response.text();
 
-    return { isSignedUp: isSignedUp, msg: msg };
+    return { isSucceeded: isSucceeded, msg: msg };
   } catch (err) {
     console.log(err);
   }


### PR DESCRIPTION
## 📝 概要
Signup/Signinページのemail, password入力のバリデーション処理追加

## 🧐 なぜこの変更をするのか
エラー防止。入力値にスペースなどエラー発生の原因になる文字が入力される可能性があるため。

### 影響のある Issue

Closes #111 

### 参照する Issue や PR

## 💪 やったこと

- 入力フォーム`<Form />`の入力値管理をstateから`react-hook-form`に変更
- Email/Passwordの入力フォームにバリデーションを設定
- Utils関数と`<Input />`のリファクタ

### スクリーンショット/動画/gif など

### テスト

- [ ] あり
- [x] なし(必要なし)
- [ ] なし(ヘルプが必要)

## 💬 課題

### 悩んでいること

### とくにレビューしてほしいところ

## その他
