### PR TITLE
[Feat] トレーニング記録の種目削除ボタン追加

### DIFF
--- a/src/app/(user)/workout/page.tsx
+++ b/src/app/(user)/workout/page.tsx
@@ -45,7 +45,13 @@ const Page: NextPage = () => {
           <Button entry="finishworkout" />
         </div>
         {exercises.map((exercise, index) => (
-          <Exercise key={index} name={exercise} register={register} />
+          <Exercise
+            key={index}
+            name={exercise}
+            register={register}
+            exercises={exercises}
+            setExercises={setExercises}
+          />
         ))}
         <Button entry="addexercises" onClick={() => setIsPopupOpen(true)} />
         <Button entry="cancelworkout" onClick={onClick} />

--- a/src/components/workout/Exercise.tsx
+++ b/src/components/workout/Exercise.tsx
@@ -7,9 +7,13 @@ import type { FieldValues, UseFormRegister } from "react-hook-form";
 const Exercise = ({
   name,
   register,
+  exercises,
+  setExercises,
 }: {
   name: string;
   register: UseFormRegister<FieldValues>;
+  exercises: string[];
+  setExercises: React.Dispatch<React.SetStateAction<string[]>>;
 }) => {
   const [sets, setSets] = useState([1]);
   const addSet = () => {
@@ -18,7 +22,19 @@ const Exercise = ({
 
   return (
     <div className="relative overflow-x-auto m-6">
-      <h2 className="text-lg">{name}</h2>
+      <div className="flex justify-between">
+        <h2 className="text-lg">{name}</h2>
+        <Button
+          entry="closeexerciselist"
+          onClick={() => {
+            const updatedExercises = exercises.filter(
+              (exercise) => exercise !== name
+            );
+
+            setExercises(updatedExercises);
+          }}
+        />
+      </div>
       <table className="w-full text-sm text-left rtl:text-right text-gray-500 dark:text-gray-400">
         <thead className="text-xs text-gray-700 uppercase dark:text-gray-400">
           <tr>


### PR DESCRIPTION
## 📝 概要
Workoutページ上の記録編集のためトレーニング種目削除のボタン追加

## 🧐 なぜこの変更をするのか
トレーニング追加はできるが削除はできなかったため

### 影響のある Issue

Closes #129 

### 参照する Issue や PR

## 💪 やったこと

- 各種目のレコードに削除用ボタンを追加

### スクリーンショット/動画/gif など

### テスト

- [ ] あり
- [x] なし(必要なし)
- [ ] なし(ヘルプが必要)

## 💬 課題

### 悩んでいること

### とくにレビューしてほしいところ

## その他
