### PR TITLE
[Feat] Histories APIに更新/削除追加

### DIFF
--- a/src/app/api/histories/route.test.ts
+++ b/src/app/api/histories/route.test.ts
@@ -1,6 +1,5 @@
-import { GET, POST } from "./route";
+import { GET, POST, PATCH } from "./route";
 import { createMocks } from "node-mocks-http";
-import { type NextApiRequest } from "next";
 import { type NextRequest } from "next/server";
 
 describe("API: histories", () => {
@@ -30,7 +29,7 @@ describe("API: histories", () => {
 
   describe("POST", () => {
     test("トレーニング記録追加", async () => {
-      const { req }: { req: NextApiRequest } = createMocks({
+      const { req }: { req: Request } = createMocks({
         method: "POST",
         body: {
           email: "test@xyz.com",
@@ -38,6 +37,52 @@ describe("API: histories", () => {
         },
       });
       const response = await POST(req);
+
+      expect(response.status).toBe(200);
+    });
+  });
+
+  describe("PATCH", () => {
+    test("トレーニング記録更新", async () => {
+      const { req }: { req: Request } = createMocks({
+        method: "PATCH",
+        body: {
+          email: "test@xyz.com",
+          workoutData: [
+            {
+              date: "2024-02-02",
+              data: [
+                [
+                  {
+                    date: "2025-02-02",
+                    data: [
+                      {
+                        name: "Bench Press",
+                        sets: [
+                          {
+                            rep: 10,
+                            weight: 100,
+                          },
+                        ],
+                      },
+                      {
+                        name: "Squat",
+                        sets: [
+                          {
+                            rep: 10,
+                            weight: 100,
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              ],
+            },
+          ],
+        },
+      });
+      const response = await PATCH(req);
 
       expect(response.status).toBe(200);
     });

--- a/src/app/api/histories/route.test.ts
+++ b/src/app/api/histories/route.test.ts
@@ -1,4 +1,4 @@
-import { GET, POST, PATCH } from "./route";
+import { GET, POST, PATCH, DELETE } from "./route";
 import { createMocks } from "node-mocks-http";
 import { type NextRequest } from "next/server";
 
@@ -83,6 +83,21 @@ describe("API: histories", () => {
         },
       });
       const response = await PATCH(req);
+
+      expect(response.status).toBe(200);
+    });
+  });
+
+  describe("DELETE", () => {
+    test("トレーニング記録削除", async () => {
+      const { req }: { req: Request } = createMocks({
+        method: "DELETE",
+        body: {
+          email: "test@xyz.com",
+          date: "2024-04-04",
+        },
+      });
+      const response = await DELETE(req);
 
       expect(response.status).toBe(200);
     });

--- a/src/app/api/histories/route.ts
+++ b/src/app/api/histories/route.ts
@@ -70,3 +70,26 @@ export async function PATCH(req: Request) {
     return new Response("サーバーエラーが発生しました", { status: 500 });
   }
 }
+
+export async function DELETE(req: Request) {
+  const { email, date } = await req.json();
+
+  try {
+    const client = createClient(
+      process.env.SUPABASE_URL as string,
+      process.env.SUPABASE_ANON_KEY as string
+    );
+    const { data, error } = await client
+      .from("histories")
+      .delete()
+      .eq("email", email)
+      .eq("date", date);
+
+    if (error) throw error;
+
+    return new Response(JSON.stringify(data));
+  } catch (err) {
+    console.log(err);
+    return new Response("サーバーエラーが発生しました", { status: 500 });
+  }
+}

--- a/src/app/api/histories/route.ts
+++ b/src/app/api/histories/route.ts
@@ -47,3 +47,26 @@ export async function POST(req: Request) {
     return new Response("サーバーエラーが発生しました", { status: 500 });
   }
 }
+
+export async function PATCH(req: Request) {
+  const { email, workoutData } = await req.json();
+
+  try {
+    const client = createClient(
+      process.env.SUPABASE_URL as string,
+      process.env.SUPABASE_ANON_KEY as string
+    );
+    const { data, error } = await client
+      .from("histories")
+      .update({ data: workoutData })
+      .eq("email", email)
+      .eq("date", workoutData[0].date);
+
+    if (error) throw error;
+
+    return new Response(JSON.stringify(data));
+  } catch (err) {
+    console.log(err);
+    return new Response("サーバーエラーが発生しました", { status: 500 });
+  }
+}


### PR DESCRIPTION
## 📝 概要
Histories APIに過去トレーニングデータを更新/削除するメソッドを追加

## 🧐 なぜこの変更をするのか
トレーニングデータのCRUD操作のUD実装のため

### 影響のある Issue

Closes #132 

### 参照する Issue や PR

## 💪 やったこと

- Histories API `/api/histories/route.ts`に`PATCH`追加
- Histories API `/api/histories/route.ts`に`DELETE`追加

### スクリーンショット/動画/gif など

### テスト

- [ ] あり
- [x] なし(必要なし)
- [ ] なし(ヘルプが必要)

## 💬 課題

### 悩んでいること

### とくにレビューしてほしいところ

## その他
