### PR TITLE
[Feat] 過去トレーニング記録の更新/削除機能ページ追加

### DIFF
--- a/src/app/(user)/dashboard/page.tsx
+++ b/src/app/(user)/dashboard/page.tsx
@@ -34,7 +34,10 @@ const Page: NextPage = () => {
         <Navbar userEmail={email} />
       </div>
       <div className="flex flex-col items-center justify-center pt-16">
-        <Button entry="startworkout" onClick={onClick} />
+        <div className="flex gap-4">
+          <Button entry="startworkout" onClick={onClick} />
+          <Button entry="edit" onClick={() => router.push("/workout/edit")} />
+        </div>
         <div className="w-full min-h-64 flex justify-center items-center">
           <History sessions={sessions} />
         </div>

--- a/src/app/(user)/dashboard/page.tsx
+++ b/src/app/(user)/dashboard/page.tsx
@@ -29,18 +29,13 @@ const Page: NextPage = () => {
   }, []);
 
   return (
-    <div className="relative">
-      <div className="fixed top-0 left-0 w-full">
-        <Navbar userEmail={email} />
+    <div className="flex flex-col items-center justify-center pt-16">
+      <div className="flex gap-4">
+        <Button entry="startworkout" onClick={onClick} />
+        <Button entry="edit" onClick={() => router.push("/workout/edit")} />
       </div>
-      <div className="flex flex-col items-center justify-center pt-16">
-        <div className="flex gap-4">
-          <Button entry="startworkout" onClick={onClick} />
-          <Button entry="edit" onClick={() => router.push("/workout/edit")} />
-        </div>
-        <div className="w-full min-h-64 flex justify-center items-center">
-          <History sessions={sessions} />
-        </div>
+      <div className="w-full min-h-64 flex justify-center items-center">
+        <History sessions={sessions} />
       </div>
     </div>
   );

--- a/src/app/(user)/layout.tsx
+++ b/src/app/(user)/layout.tsx
@@ -1,8 +1,19 @@
 "use client";
 
-import { NoAuthUserRedirection } from "@/components";
+import { Navbar, NoAuthUserRedirection } from "@/components";
 
 const Layout = ({ children }: { children: React.ReactNode }) => {
-  return <NoAuthUserRedirection>{children}</NoAuthUserRedirection>;
+  const email = localStorage.getItem("email");
+
+  return (
+    <NoAuthUserRedirection>
+      <div className="relative">
+        <div className="fixed top-0 left-0 w-full">
+          <Navbar userEmail={email as string} />
+        </div>
+        <div className="mt-10">{children}</div>
+      </div>
+    </NoAuthUserRedirection>
+  );
 };
 export default Layout;

--- a/src/app/(user)/workout/edit/page.stories.ts
+++ b/src/app/(user)/workout/edit/page.stories.ts
@@ -1,0 +1,22 @@
+import { Meta } from "@storybook/react";
+import Page from "./page";
+
+const meta: Meta<typeof Page> = {
+  title: "Pages/User/Workout/Edit",
+  component: Page,
+  tags: ["autodocs"],
+  parameters: {
+    docs: {
+      description: {
+        component: "過去のトレーニング記録を更新/削除することができる",
+      },
+    },
+    nextjs: {
+      appDirectory: true,
+    },
+  },
+};
+
+export default meta;
+
+export const Default = {};

--- a/src/app/(user)/workout/edit/page.tsx
+++ b/src/app/(user)/workout/edit/page.tsx
@@ -1,0 +1,7 @@
+import type { NextPage } from "next";
+
+const Page: NextPage = () => {
+  return <></>;
+};
+
+export default Page;

--- a/src/app/(user)/workout/edit/page.tsx
+++ b/src/app/(user)/workout/edit/page.tsx
@@ -37,6 +37,21 @@ const Page: NextPage = () => {
 
     if (res.ok) router.push("/dashboard");
   };
+  const onDeleteClick = async () => {
+    const isConfirmed = window.confirm("本当に削除しますか？");
+
+    if (!isConfirmed) return;
+
+    const res = await fetch(`${process.env.NEXT_PUBLIC_HOST}/api/histories`, {
+      method: "DELETE",
+      body: JSON.stringify({
+        email: email,
+        date: selectedDate,
+      }),
+    });
+
+    if (res.ok) router.push("/dashboard");
+  };
 
   useEffect(() => {
     const fetchWorkoutHistories = async () => {
@@ -85,12 +100,15 @@ const Page: NextPage = () => {
           onAddClick={() => setIsPopupOpen(false)}
         />
       )}
-      <Button
-        entry="edit"
-        onClick={() => {
-          setIsEditMode((prev) => !prev);
-        }}
-      />
+      <div className="flex gap-4">
+        <Button
+          entry="edit"
+          onClick={() => {
+            setIsEditMode((prev) => !prev);
+          }}
+        />
+        <Button entry="delete" onClick={onDeleteClick} />
+      </div>
       {isEditMode && (
         <form
           className="w-full max-w-xs sm:max-w-sm md:max-w-md lg:max-w-lg mx-auto"

--- a/src/app/(user)/workout/edit/page.tsx
+++ b/src/app/(user)/workout/edit/page.tsx
@@ -2,6 +2,10 @@
 
 import type { NextPage } from "next";
 import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useForm } from "react-hook-form";
+import { Button, Exercise, ExerciseListPopUp, History } from "@/components";
+import { formatSubmitData } from "../page";
 
 type WorkoutSet = { rep: number; weight: number };
 type workoutHistory = {
@@ -16,6 +20,23 @@ const Page: NextPage = () => {
   const [workoutHistories, setWorkoutHistories] = useState<workoutHistory[]>(
     []
   );
+  const [selectedHistory, setSelectedHistory] = useState<workoutHistory>();
+  const [selectedDate, setSelectedDate] = useState<string>("");
+  const [isPopupOpen, setIsPopupOpen] = useState(false);
+  const [isEditMode, setIsEditMode] = useState(false);
+  const [exercises, setExercises] = useState<string[]>([]);
+  const email = localStorage.getItem("email");
+  const router = useRouter();
+  const { register, handleSubmit } = useForm();
+  const onSubmit = async (data: any) => {
+    const formattedData = formatSubmitData(selectedDate, data);
+    const res = await fetch(`${process.env.NEXT_PUBLIC_HOST}/api/histories`, {
+      method: "PATCH",
+      body: JSON.stringify({ email: email, workoutData: formattedData }),
+    });
+
+    if (res.ok) router.push("/dashboard");
+  };
 
   useEffect(() => {
     const fetchWorkoutHistories = async () => {
@@ -25,27 +46,77 @@ const Page: NextPage = () => {
         }/api/histories?email=${localStorage.getItem("email")}`
       );
       const data = await res.json();
-      const histories = data[0].data;
-
-      console.log(histories);
+      const histories = data.map((history: workoutHistory) => history.data[0]);
 
       setWorkoutHistories(histories);
     };
 
     fetchWorkoutHistories();
   }, []);
+  useEffect(() => {
+    const history = workoutHistories.find((hstr) => hstr.date === selectedDate);
+
+    setSelectedHistory(history);
+  }, [selectedDate]);
 
   return (
-    <>
-      <label htmlFor="dates">日付</label>
-      <select name="dates">
-        {workoutHistories.map((history) => (
-          <option value={history.date} key={history.date}>
-            {history.date}
-          </option>
-        ))}
-      </select>
-    </>
+    <div className="w-auto flex flex-col justify-center items-center gap-4">
+      <div className="flex gap-4">
+        <label htmlFor="dates">日付</label>
+        <select
+          name="dates"
+          value={selectedDate}
+          onChange={(e) => {
+            setSelectedDate(e.target.value);
+          }}
+        >
+          {workoutHistories.map((history) => (
+            <option value={history.date} key={history.date}>
+              {history.date}
+            </option>
+          ))}
+        </select>
+      </div>
+      <History sessions={selectedHistory ? [selectedHistory] : []} />
+      {isPopupOpen && (
+        <ExerciseListPopUp
+          setExercises={setExercises}
+          onCancelClick={() => setIsPopupOpen(false)}
+          onAddClick={() => setIsPopupOpen(false)}
+        />
+      )}
+      <Button
+        entry="edit"
+        onClick={() => {
+          setIsEditMode((prev) => !prev);
+        }}
+      />
+      {isEditMode && (
+        <form
+          className="w-full max-w-xs sm:max-w-sm md:max-w-md lg:max-w-lg mx-auto"
+          onSubmit={handleSubmit(onSubmit)}
+        >
+          <div className="flex pt-10 justify-between items-center">
+            <h1>{selectedDate}</h1>
+            <Button entry="finishworkout" />
+          </div>
+          {exercises.map((exercise, index) => (
+            <Exercise
+              key={index}
+              name={exercise}
+              register={register}
+              exercises={exercises}
+              setExercises={setExercises}
+            />
+          ))}
+          <Button entry="addexercises" onClick={() => setIsPopupOpen(true)} />
+          <Button
+            entry="cancelworkout"
+            onClick={() => router.push("/dashboard")}
+          />
+        </form>
+      )}
+    </div>
   );
 };
 

--- a/src/app/(user)/workout/edit/page.tsx
+++ b/src/app/(user)/workout/edit/page.tsx
@@ -1,7 +1,52 @@
+"use client";
+
 import type { NextPage } from "next";
+import { useEffect, useState } from "react";
+
+type WorkoutSet = { rep: number; weight: number };
+type workoutHistory = {
+  date: string;
+  data: {
+    name: string;
+    sets: WorkoutSet[];
+  }[];
+};
 
 const Page: NextPage = () => {
-  return <></>;
+  const [workoutHistories, setWorkoutHistories] = useState<workoutHistory[]>(
+    []
+  );
+
+  useEffect(() => {
+    const fetchWorkoutHistories = async () => {
+      const res = await fetch(
+        `${
+          process.env.NEXT_PUBLIC_HOST
+        }/api/histories?email=${localStorage.getItem("email")}`
+      );
+      const data = await res.json();
+      const histories = data[0].data;
+
+      console.log(histories);
+
+      setWorkoutHistories(histories);
+    };
+
+    fetchWorkoutHistories();
+  }, []);
+
+  return (
+    <>
+      <label htmlFor="dates">日付</label>
+      <select name="dates">
+        {workoutHistories.map((history) => (
+          <option value={history.date} key={history.date}>
+            {history.date}
+          </option>
+        ))}
+      </select>
+    </>
+  );
 };
 
 export default Page;

--- a/src/app/(user)/workout/page.tsx
+++ b/src/app/(user)/workout/page.tsx
@@ -62,7 +62,7 @@ const Page: NextPage = () => {
 
 export default Page;
 
-const formatSubmitData = (date: any, data: any) => {
+export const formatSubmitData = (date: any, data: any) => {
   const formattedData: any = [{ date: date, data: [] }];
   const exerciseNames = Object.keys(data);
 

--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -41,6 +41,20 @@ const Button = ({ entry, onClick }: ButtonProps) => {
             X
           </button>
         )}
+        {entry === "edit" && (
+          <button type="button" className={className} onClick={onClick}>
+            EDIT
+          </button>
+        )}
+        {entry === "delete" && (
+          <button
+            type="button"
+            className="w-full py-3 px-4 text-sm tracking-wide rounded-lg text-white bg-rose-400 mt-2 hover:bg-rose-300 focus:outline-none"
+            onClick={onClick}
+          >
+            DELETE
+          </button>
+        )}
       </div>
     </div>
   );

--- a/src/components/common/Navbar.tsx
+++ b/src/components/common/Navbar.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import Link from "next/link";
 import { SignoutButton } from "@/components";
 
 export type NavbarProps = {
@@ -10,9 +11,9 @@ const Navbar = ({ userEmail }: NavbarProps) => {
     <div>
       <ul className="flex justify-between items-center bg-gray-200 px-10">
         <li className="mr-3">
-          <a className="text-gray-500 hover:text-gray-700" href="#">
+          <Link className="text-gray-500 hover:text-gray-700" href="/dashboard">
             HOME
-          </a>
+          </Link>
         </li>
         <li className="mr-3 flex items-center gap-4">
           <SignoutButton />

--- a/src/components/common/types.d.ts
+++ b/src/components/common/types.d.ts
@@ -7,6 +7,8 @@ export type ButtonProps = {
     | "addset"
     | "addexercises"
     | "cancelworkout"
-    | "closeexerciselist";
+    | "closeexerciselist"
+    | "edit"
+    | "delete";
   onClick?: (e: any) => void;
 };


### PR DESCRIPTION
## 📝 概要
過去に登録したトレーニング記録を更新または削除するページ作成

## 🧐 なぜこの変更をするのか
CRUD機能のうちUDが未実装のため

### 影響のある Issue

Closes #131

### 参照する Issue や PR

## 💪 やったこと

- 更新/削除用ページ`/workout/edit`を追加
- ダッシュボードページからの更新ページへのリンク追加

### スクリーンショット/動画/gif など

### テスト

- [ ] あり
- [x] なし(必要なし)
- [ ] なし(ヘルプが必要)

## 💬 課題

### 悩んでいること

### とくにレビューしてほしいところ

## その他
