### PR TITLE
[Fix] デプロイエラー解消のためworkoutページ内の関数を移行

### DIFF
--- a/src/app/(user)/workout/edit/page.tsx
+++ b/src/app/(user)/workout/edit/page.tsx
@@ -5,7 +5,7 @@ import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useForm } from "react-hook-form";
 import { Button, Exercise, ExerciseListPopUp, History } from "@/components";
-import { formatSubmitData } from "../page";
+import { formatSubmitData } from "../formatSubmitData";
 
 type WorkoutSet = { rep: number; weight: number };
 type workoutHistory = {

--- a/src/app/(user)/workout/formatSubmitData.ts
+++ b/src/app/(user)/workout/formatSubmitData.ts
@@ -1,0 +1,12 @@
+export const formatSubmitData = (date: any, data: any) => {
+  const formattedData: any = [{ date: date, data: [] }];
+  const exerciseNames = Object.keys(data);
+
+  exerciseNames.forEach((name: string) => {
+    const sets = data[name];
+
+    formattedData[0].data.push({ name, sets });
+  });
+
+  return formattedData;
+};

--- a/src/app/(user)/workout/page.tsx
+++ b/src/app/(user)/workout/page.tsx
@@ -5,6 +5,7 @@ import React, { useEffect, useState } from "react";
 import { Button, Exercise, ExerciseListPopUp } from "@/components";
 import { useRouter } from "next/navigation";
 import { useForm } from "react-hook-form";
+import { formatSubmitData } from "./formatSubmitData";
 
 const Page: NextPage = () => {
   const [currentDate, setCurrentDate] = useState<string>("");
@@ -61,16 +62,3 @@ const Page: NextPage = () => {
 };
 
 export default Page;
-
-export const formatSubmitData = (date: any, data: any) => {
-  const formattedData: any = [{ date: date, data: [] }];
-  const exerciseNames = Object.keys(data);
-
-  exerciseNames.forEach((name: string) => {
-    const sets = data[name];
-
-    formattedData[0].data.push({ name, sets });
-  });
-
-  return formattedData;
-};


### PR DESCRIPTION
## 📝 概要
デプロイエラー解消のためworkoutページ内の関数を移行

## 🧐 なぜこの変更をするのか
Vercelデプロイができないため

### 影響のある Issue

Closes #

### 参照する Issue や PR

## 💪 やったこと

- `/workout`配下のページにて共通利用している`formatSubmitData`を移行

### スクリーンショット/動画/gif など

### テスト

- [ ] あり
- [x] なし(必要なし)
- [ ] なし(ヘルプが必要)

## 💬 課題

### 悩んでいること

### とくにレビューしてほしいところ

## その他
